### PR TITLE
feat: use env for auth callback redirect

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -113,7 +113,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: window.location.origin,
+          redirectTo: `${import.meta.env.VITE_SITE_URL}/auth/callback`,
           queryParams: { prompt: "select_account" },
         },
       });
@@ -128,7 +128,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: window.location.origin,
+          redirectTo: `${import.meta.env.VITE_SITE_URL}/auth/callback`,
           queryParams: { prompt: "select_account" },
         },
       });


### PR DESCRIPTION
## Summary
- configure Supabase OAuth redirect to use `${import.meta.env.VITE_SITE_URL}/auth/callback`

## Testing
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*
- `VITE_SITE_URL=http://localhost:5173 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689692b9df90832d97b72275de70d8ba