### PR TITLE
fix: remove default admin email

### DIFF
--- a/src/pages/admin/Login.tsx
+++ b/src/pages/admin/Login.tsx
@@ -15,7 +15,7 @@ import { supabase } from "@/integrations/supabase/client";
 export default function AdminLogin() {
   const { signInAdmin } = useAuth();
   const { toast } = useToast();
-  const [email, setEmail] = useState("comasnicolas@gmail.com");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
 


### PR DESCRIPTION
## Summary
- initialize admin login email state as an empty string so no default email is prefilled

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and require import errors in existing files)
- `npx eslint src/pages/admin/Login.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6896c959d280832db58fbf122ef32786