### PR TITLE
Fetch team member emails for display

### DIFF
--- a/src/hooks/useTeam.ts
+++ b/src/hooks/useTeam.ts
@@ -66,12 +66,21 @@ export function useTeamMembers() {
 
       if (profilesError) throw profilesError;
 
+      // Get email addresses from auth.users
+      const { data: users, error: usersError } = await (supabase as any)
+        .from('auth.users')
+        .select('id, email')
+        .in('id', userIds);
+
+      if (usersError) throw usersError;
+
       const members = roles.map(role => {
         const profile = profiles?.find(p => p.id === role.user_id);
+        const user = users?.find(u => u.id === role.user_id);
         return {
           ...role,
           full_name: profile?.full_name,
-          email: undefined, // We'll get this from auth if needed
+          email: user?.email,
         };
       });
 


### PR DESCRIPTION
## Summary
- retrieve each member's email by querying `auth.users`
- attach email and full name when building the team members list

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/roast-stream-connect/node_modules/globals/index.js' imported from /workspace/roast-stream-connect/eslint.config.js)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c96942f4832d8e347365bd45c603