### PR TITLE
docs: add index and naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ npm run dev
 - Click on "New codespace" to launch a new Codespace environment.
 - Edit files directly within the Codespace and commit and push your changes once you're done.
 
+## Documentation
+
+Consulta el [índice de documentación](docs/README.md) para ver los archivos disponibles y las convenciones de nombres.
+
 ## What technologies are used for this project?
 
 This project is built with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Índice de documentación
+
+Este directorio contiene referencias y guías relacionadas con el proyecto.
+
+## Documentos disponibles
+
+- [SECURITY.md](./SECURITY.md) – pautas de seguridad y manejo de variables de entorno.
+- [edge-functions-cors-testing.md](./edge-functions-cors-testing.md) – guía para probar CORS en Edge Functions con ejemplos de curl y navegador.
+- [pos-sync/operacion.md](./pos-sync/operacion.md) – runbook de operación diaria del proceso `pos-sync-daily`.
+- [tupa-hub-tech-report.md](./tupa-hub-tech-report.md) – informe técnico ejecutivo del proyecto TUPÁ Hub.
+
+## Convención de nombres
+
+Para futuros documentos en `docs/` se recomienda usar prefijos temáticos en minúsculas que indiquen su propósito:
+
+- `guide-` para guías prácticas.
+- `ops-` para runbooks y procedimientos operativos.
+- `report-` para informes técnicos o ejecutivos.
+- `security-` para lineamientos de seguridad.
+
+El formato sugerido es `<prefijo>-<descripcion>.md`, ubicado en este directorio o en subcarpetas cuando corresponda.


### PR DESCRIPTION
## Summary
- index existing documentation and add naming convention guidance
- link main README to docs index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a246404cc0832d98d190468127d535